### PR TITLE
Fix Calendar header component usage

### DIFF
--- a/src/pages/Calendar.jsx
+++ b/src/pages/Calendar.jsx
@@ -1,14 +1,12 @@
 import React from 'react';
-import { ScheduleComponent, ViewsDirective, ViewDirective, Day, Week, WorkWeek, Month, Agenda, Inject, Resize, DragAndDrop } from '@syncfusion/ej2-react-schedule';
-import { DatePickerComponent } from '@syncfusion/ej2-react-calendars';
+import { ScheduleComponent, Day, Week, WorkWeek, Month, Agenda, Inject, Resize, DragAndDrop } from '@syncfusion/ej2-react-schedule';
 
-import { scheduleData } from '../data/dummy';
 import { Header } from '../components';
 
 const Calendar = () => {
   return (
-      <div className='m-2 md:m-10 mt-24 p-2 md:p-10 bg-white rounded-3xl'>
-          <header category="App" title='Calendar' />
+        <div className='m-2 md:m-10 mt-24 p-2 md:p-10 bg-white rounded-3xl'>
+            <Header category="App" title="Calendar" />
           <ScheduleComponent>
               <Inject services={[Day, Week, WorkWeek, Month, Agenda, Resize, DragAndDrop]} />
           </ScheduleComponent>


### PR DESCRIPTION
## Summary
- replace `<header>` placeholder with actual `Header` component
- remove unused imports

## Testing
- `npm test` *(fails: No tests found)*

------
https://chatgpt.com/codex/tasks/task_e_6849ff942a188323adf55a6aad58bb90