### PR TITLE
Remove unused components

### DIFF
--- a/src/components/ChartsHeader.jsx
+++ b/src/components/ChartsHeader.jsx
@@ -1,9 +1,0 @@
-import React from 'react'
-
-const ChartsHeader = () => {
-  return (
-    <div>ChartsHeader</div>
-  )
-}
-
-export default ChartsHeader

--- a/src/components/Footer.jsx
+++ b/src/components/Footer.jsx
@@ -1,9 +1,0 @@
-import React from 'react'
-
-const Footer = () => {
-  return (
-    <div>Footer</div>
-  )
-}
-
-export default Footer

--- a/src/components/index.jsx
+++ b/src/components/index.jsx
@@ -2,6 +2,4 @@ export { default as ThemeSettings } from './ThemeSettings';
 export { default as Sidebar } from './Sidebar';
 // eslint-disable-next-line import/no-cycle
 export { default as Navbar } from './Navbar';
-export { default as Footer } from './Footer';
-export { default as ChartsHeader } from './ChartsHeader';
 export { default as Header } from './Header';


### PR DESCRIPTION
## Summary
- delete unused `Footer` and `ChartsHeader` components
- drop their exports from the components index

## Testing
- `npm test -- --watchAll=false`

------
https://chatgpt.com/codex/tasks/task_e_684b3c1b97b88323a37b233d4e649878