### PR TITLE
Implement content and license forms

### DIFF
--- a/src/pages/Content/AddContent.jsx
+++ b/src/pages/Content/AddContent.jsx
@@ -1,9 +1,88 @@
-import React from 'react'
+import React, { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import apiClient from '../../api/client';
+import { Header } from '../../components';
 
 const AddContent = () => {
-  return (
-    <div>AddContent</div>
-  )
-}
+  const navigate = useNavigate();
+  const [formData, setFormData] = useState({
+    name: '',
+    status: '',
+    posterUrl: '',
+    videoUrl: '',
+  });
+  const [message, setMessage] = useState('');
 
-export default AddContent
+  const handleChange = (e) => {
+    setFormData({ ...formData, [e.target.name]: e.target.value });
+  };
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    if (!formData.name || !formData.status || !formData.posterUrl || !formData.videoUrl) {
+      setMessage('All fields are required.');
+      return;
+    }
+    try {
+      await apiClient.post('/contents', formData);
+      setMessage('Content added successfully.');
+      navigate('/All%20contents');
+    } catch (err) {
+      setMessage('Failed to add content.');
+    }
+  };
+
+  return (
+    <div className='m-2 md:m-10 p-2 md:p-10 bg-white rounded-3xl'>
+      <Header category='Contents' title='Add content' />
+      <form onSubmit={handleSubmit} className='space-y-4'>
+        <div>
+          <label className='block mb-1'>Name</label>
+          <input
+            type='text'
+            name='name'
+            value={formData.name}
+            onChange={handleChange}
+            className='border p-2 rounded w-full'
+          />
+        </div>
+        <div>
+          <label className='block mb-1'>Status</label>
+          <input
+            type='text'
+            name='status'
+            value={formData.status}
+            onChange={handleChange}
+            className='border p-2 rounded w-full'
+          />
+        </div>
+        <div>
+          <label className='block mb-1'>Poster URL</label>
+          <input
+            type='text'
+            name='posterUrl'
+            value={formData.posterUrl}
+            onChange={handleChange}
+            className='border p-2 rounded w-full'
+          />
+        </div>
+        <div>
+          <label className='block mb-1'>Video URL</label>
+          <input
+            type='text'
+            name='videoUrl'
+            value={formData.videoUrl}
+            onChange={handleChange}
+            className='border p-2 rounded w-full'
+          />
+        </div>
+        <button type='submit' className='px-4 py-2 bg-blue-600 text-white rounded'>
+          Submit
+        </button>
+      </form>
+      {message && <p className='mt-4'>{message}</p>}
+    </div>
+  );
+};
+
+export default AddContent;

--- a/src/pages/Content/DeleteContent.jsx
+++ b/src/pages/Content/DeleteContent.jsx
@@ -1,9 +1,48 @@
-import React from 'react'
+import React, { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import apiClient from '../../api/client';
+import { Header } from '../../components';
 
 const DeleteContent = () => {
-  return (
-    <div>DeleteContent</div>
-  )
-}
+  const [contentId, setContentId] = useState('');
+  const [message, setMessage] = useState('');
+  const navigate = useNavigate();
 
-export default DeleteContent
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    if (!contentId) {
+      setMessage('Content ID is required.');
+      return;
+    }
+    try {
+      await apiClient.delete(`/contents/${contentId}`);
+      setMessage('Content deleted successfully.');
+      navigate('/All%20contents');
+    } catch (err) {
+      setMessage('Failed to delete content.');
+    }
+  };
+
+  return (
+    <div className='m-2 md:m-10 p-2 md:p-10 bg-white rounded-3xl'>
+      <Header category='Contents' title='Delete content' />
+      <form onSubmit={handleSubmit} className='space-y-4'>
+        <div>
+          <label className='block mb-1'>Content ID</label>
+          <input
+            type='text'
+            value={contentId}
+            onChange={(e) => setContentId(e.target.value)}
+            className='border p-2 rounded w-full'
+          />
+        </div>
+        <button type='submit' className='px-4 py-2 bg-red-600 text-white rounded'>
+          Delete
+        </button>
+      </form>
+      {message && <p className='mt-4'>{message}</p>}
+    </div>
+  );
+};
+
+export default DeleteContent;

--- a/src/pages/Content/UpdateContent.jsx
+++ b/src/pages/Content/UpdateContent.jsx
@@ -1,9 +1,123 @@
-import React from 'react'
+import React, { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import apiClient from '../../api/client';
+import { Header } from '../../components';
 
 const UpdateContent = () => {
-  return (
-    <div>UpdateContent</div>
-  )
-}
+  const [contentId, setContentId] = useState('');
+  const [formData, setFormData] = useState({
+    name: '',
+    status: '',
+    posterUrl: '',
+    videoUrl: '',
+  });
+  const [message, setMessage] = useState('');
+  const navigate = useNavigate();
 
-export default UpdateContent
+  const handleChange = (e) => {
+    setFormData({ ...formData, [e.target.name]: e.target.value });
+  };
+
+  const fetchContent = async () => {
+    if (!contentId) {
+      setMessage('Content ID is required.');
+      return;
+    }
+    try {
+      const res = await apiClient.get(`/contents/${contentId}`);
+      const { Name, Status, PosterUrl, VideoUrl } = res.data;
+      setFormData({
+        name: Name || '',
+        status: Status || '',
+        posterUrl: PosterUrl || '',
+        videoUrl: VideoUrl || '',
+      });
+      setMessage('');
+    } catch (err) {
+      setMessage('Failed to fetch content.');
+    }
+  };
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    if (!contentId || !formData.name || !formData.status || !formData.posterUrl || !formData.videoUrl) {
+      setMessage('All fields are required.');
+      return;
+    }
+    try {
+      await apiClient.put(`/contents/${contentId}`, formData);
+      setMessage('Content updated successfully.');
+      navigate('/All%20contents');
+    } catch (err) {
+      setMessage('Failed to update content.');
+    }
+  };
+
+  return (
+    <div className='m-2 md:m-10 p-2 md:p-10 bg-white rounded-3xl'>
+      <Header category='Contents' title='Update content' />
+      <div className='space-y-4'>
+        <div>
+          <label className='block mb-1'>Content ID</label>
+          <input
+            type='text'
+            value={contentId}
+            onChange={(e) => setContentId(e.target.value)}
+            className='border p-2 rounded w-full'
+          />
+          <button type='button' onClick={fetchContent} className='mt-2 px-4 py-2 bg-gray-300 rounded'>
+            Load
+          </button>
+        </div>
+        <form onSubmit={handleSubmit} className='space-y-4'>
+          <div>
+            <label className='block mb-1'>Name</label>
+            <input
+              type='text'
+              name='name'
+              value={formData.name}
+              onChange={handleChange}
+              className='border p-2 rounded w-full'
+            />
+          </div>
+          <div>
+            <label className='block mb-1'>Status</label>
+            <input
+              type='text'
+              name='status'
+              value={formData.status}
+              onChange={handleChange}
+              className='border p-2 rounded w-full'
+            />
+          </div>
+          <div>
+            <label className='block mb-1'>Poster URL</label>
+            <input
+              type='text'
+              name='posterUrl'
+              value={formData.posterUrl}
+              onChange={handleChange}
+              className='border p-2 rounded w-full'
+            />
+          </div>
+          <div>
+            <label className='block mb-1'>Video URL</label>
+            <input
+              type='text'
+              name='videoUrl'
+              value={formData.videoUrl}
+              onChange={handleChange}
+              className='border p-2 rounded w-full'
+            />
+          </div>
+          <button type='submit' className='px-4 py-2 bg-blue-600 text-white rounded'>
+            Update
+          </button>
+        </form>
+        {message && <p className='mt-4'>{message}</p>}
+      </div>
+    </div>
+  );
+};
+
+export default UpdateContent;

--- a/src/pages/License/AddLicense.jsx
+++ b/src/pages/License/AddLicense.jsx
@@ -1,9 +1,88 @@
-import React from 'react'
+import React, { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import apiClient from '../../api/client';
+import { Header } from '../../components';
 
 const AddLicense = () => {
-  return (
-    <div>AddLicense</div>
-  )
-}
+  const navigate = useNavigate();
+  const [formData, setFormData] = useState({
+    name: '',
+    startTime: '',
+    endTime: '',
+    licenseCode: '',
+  });
+  const [message, setMessage] = useState('');
 
-export default AddLicense
+  const handleChange = (e) => {
+    setFormData({ ...formData, [e.target.name]: e.target.value });
+  };
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    if (!formData.name || !formData.startTime || !formData.endTime || !formData.licenseCode) {
+      setMessage('All fields are required.');
+      return;
+    }
+    try {
+      await apiClient.post('/licenses', formData);
+      setMessage('License added successfully.');
+      navigate('/Show%20licenses');
+    } catch (err) {
+      setMessage('Failed to add license.');
+    }
+  };
+
+  return (
+    <div className='m-2 md:m-10 p-2 md:p-10 bg-white rounded-3xl'>
+      <Header category='License' title='Add license' />
+      <form onSubmit={handleSubmit} className='space-y-4'>
+        <div>
+          <label className='block mb-1'>Name</label>
+          <input
+            type='text'
+            name='name'
+            value={formData.name}
+            onChange={handleChange}
+            className='border p-2 rounded w-full'
+          />
+        </div>
+        <div>
+          <label className='block mb-1'>Start Time</label>
+          <input
+            type='text'
+            name='startTime'
+            value={formData.startTime}
+            onChange={handleChange}
+            className='border p-2 rounded w-full'
+          />
+        </div>
+        <div>
+          <label className='block mb-1'>End Time</label>
+          <input
+            type='text'
+            name='endTime'
+            value={formData.endTime}
+            onChange={handleChange}
+            className='border p-2 rounded w-full'
+          />
+        </div>
+        <div>
+          <label className='block mb-1'>License Code</label>
+          <input
+            type='text'
+            name='licenseCode'
+            value={formData.licenseCode}
+            onChange={handleChange}
+            className='border p-2 rounded w-full'
+          />
+        </div>
+        <button type='submit' className='px-4 py-2 bg-blue-600 text-white rounded'>
+          Submit
+        </button>
+      </form>
+      {message && <p className='mt-4'>{message}</p>}
+    </div>
+  );
+};
+
+export default AddLicense;

--- a/src/pages/License/DeleteLicense.jsx
+++ b/src/pages/License/DeleteLicense.jsx
@@ -1,9 +1,48 @@
-import React from 'react'
+import React, { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import apiClient from '../../api/client';
+import { Header } from '../../components';
 
 const DeleteLicense = () => {
-  return (
-    <div>DeleteLicense</div>
-  )
-}
+  const [licenseId, setLicenseId] = useState('');
+  const [message, setMessage] = useState('');
+  const navigate = useNavigate();
 
-export default DeleteLicense
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    if (!licenseId) {
+      setMessage('License ID is required.');
+      return;
+    }
+    try {
+      await apiClient.delete(`/licenses/${licenseId}`);
+      setMessage('License deleted successfully.');
+      navigate('/Show%20licenses');
+    } catch (err) {
+      setMessage('Failed to delete license.');
+    }
+  };
+
+  return (
+    <div className='m-2 md:m-10 p-2 md:p-10 bg-white rounded-3xl'>
+      <Header category='License' title='Delete license' />
+      <form onSubmit={handleSubmit} className='space-y-4'>
+        <div>
+          <label className='block mb-1'>License ID</label>
+          <input
+            type='text'
+            value={licenseId}
+            onChange={(e) => setLicenseId(e.target.value)}
+            className='border p-2 rounded w-full'
+          />
+        </div>
+        <button type='submit' className='px-4 py-2 bg-red-600 text-white rounded'>
+          Delete
+        </button>
+      </form>
+      {message && <p className='mt-4'>{message}</p>}
+    </div>
+  );
+};
+
+export default DeleteLicense;

--- a/src/pages/License/UpdateLicense.jsx
+++ b/src/pages/License/UpdateLicense.jsx
@@ -1,9 +1,123 @@
-import React from 'react'
+import React, { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import apiClient from '../../api/client';
+import { Header } from '../../components';
 
 const UpdateLicense = () => {
-  return (
-    <div>UpdateLicense</div>
-  )
-}
+  const [licenseId, setLicenseId] = useState('');
+  const [formData, setFormData] = useState({
+    name: '',
+    startTime: '',
+    endTime: '',
+    licenseCode: '',
+  });
+  const [message, setMessage] = useState('');
+  const navigate = useNavigate();
 
-export default UpdateLicense
+  const handleChange = (e) => {
+    setFormData({ ...formData, [e.target.name]: e.target.value });
+  };
+
+  const fetchLicense = async () => {
+    if (!licenseId) {
+      setMessage('License ID is required.');
+      return;
+    }
+    try {
+      const res = await apiClient.get(`/licenses/${licenseId}`);
+      const { Name, StartTime, EndTime, LicenseCode } = res.data;
+      setFormData({
+        name: Name || '',
+        startTime: StartTime || '',
+        endTime: EndTime || '',
+        licenseCode: LicenseCode || '',
+      });
+      setMessage('');
+    } catch (err) {
+      setMessage('Failed to fetch license.');
+    }
+  };
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    if (!licenseId || !formData.name || !formData.startTime || !formData.endTime || !formData.licenseCode) {
+      setMessage('All fields are required.');
+      return;
+    }
+    try {
+      await apiClient.put(`/licenses/${licenseId}`, formData);
+      setMessage('License updated successfully.');
+      navigate('/Show%20licenses');
+    } catch (err) {
+      setMessage('Failed to update license.');
+    }
+  };
+
+  return (
+    <div className='m-2 md:m-10 p-2 md:p-10 bg-white rounded-3xl'>
+      <Header category='License' title='Update license' />
+      <div className='space-y-4'>
+        <div>
+          <label className='block mb-1'>License ID</label>
+          <input
+            type='text'
+            value={licenseId}
+            onChange={(e) => setLicenseId(e.target.value)}
+            className='border p-2 rounded w-full'
+          />
+          <button type='button' onClick={fetchLicense} className='mt-2 px-4 py-2 bg-gray-300 rounded'>
+            Load
+          </button>
+        </div>
+        <form onSubmit={handleSubmit} className='space-y-4'>
+          <div>
+            <label className='block mb-1'>Name</label>
+            <input
+              type='text'
+              name='name'
+              value={formData.name}
+              onChange={handleChange}
+              className='border p-2 rounded w-full'
+            />
+          </div>
+          <div>
+            <label className='block mb-1'>Start Time</label>
+            <input
+              type='text'
+              name='startTime'
+              value={formData.startTime}
+              onChange={handleChange}
+              className='border p-2 rounded w-full'
+            />
+          </div>
+          <div>
+            <label className='block mb-1'>End Time</label>
+            <input
+              type='text'
+              name='endTime'
+              value={formData.endTime}
+              onChange={handleChange}
+              className='border p-2 rounded w-full'
+            />
+          </div>
+          <div>
+            <label className='block mb-1'>License Code</label>
+            <input
+              type='text'
+              name='licenseCode'
+              value={formData.licenseCode}
+              onChange={handleChange}
+              className='border p-2 rounded w-full'
+            />
+          </div>
+          <button type='submit' className='px-4 py-2 bg-blue-600 text-white rounded'>
+            Update
+          </button>
+        </form>
+        {message && <p className='mt-4'>{message}</p>}
+      </div>
+    </div>
+  );
+};
+
+export default UpdateLicense;


### PR DESCRIPTION
## Summary
- create functional forms for adding, updating and deleting contents
- add forms for license CRUD pages
- wire pages to API client and redirect on success

## Testing
- `npm test -- --watchAll=false`

------
https://chatgpt.com/codex/tasks/task_e_684b42cd4b148323a7add1c78aef368e