### PR TITLE
Implement theme settings

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -11,16 +11,35 @@ import { useStateContext } from "./contexts/ContextProvider";
 import "./App.css";
 
 const App = () => {
-  const { setCurrentColor, setCurrentMode, currentMode, activeMenu, currentColor, themeSettings, setThemeSettings } = useStateContext();
+  const {
+    setCurrentColor,
+    setCurrentMode,
+    currentMode,
+    activeMenu,
+    currentColor,
+    themeSettings,
+    setThemeSettings,
+  } = useStateContext();
+
+  useEffect(() => {
+    const currentThemeColor = localStorage.getItem('colorMode');
+    const currentThemeMode = localStorage.getItem('themeMode');
+    if (currentThemeColor) setCurrentColor(currentThemeColor);
+    if (currentThemeMode) setCurrentMode(currentThemeMode);
+  }, []);
 
   return (
-    <div>
+    <div className={currentMode === 'Dark' ? 'dark' : ''}>
       <BrowserRouter>
         <div className="flex relative dark:bg-main-bg">
           <div className="fixed right-4 bottom-4" style={{ zIndex: "1000" }}>
             <TooltipComponent content="Settings" position="Top">
-              <button type="button" className="text-3xl p-3 hover:drop-shadow-xl hover:bg-light-gray text-white"
-                style={{ background: "#E50914", borderRadius: "50%" }}>
+              <button
+                type="button"
+                onClick={() => setThemeSettings(true)}
+                className="text-3xl p-3 hover:drop-shadow-xl hover:bg-light-gray text-white"
+                style={{ background: currentColor, borderRadius: '50%' }}
+              >
                 <FiSettings />
               </button>
             </TooltipComponent>

--- a/src/components/ThemeSettings.jsx
+++ b/src/components/ThemeSettings.jsx
@@ -1,9 +1,93 @@
-import React from 'react'
+import React from 'react';
+import { MdOutlineCancel } from 'react-icons/md';
+import { BsCheck } from 'react-icons/bs';
+import { themeColors } from '../data/dummy';
+import { useStateContext } from '../contexts/ContextProvider';
 
 const ThemeSettings = () => {
-  return (
-    <div>ThemeSettings</div>
-  )
-}
+  const {
+    setThemeSettings,
+    setCurrentColor,
+    setCurrentMode,
+    currentMode,
+    currentColor,
+  } = useStateContext();
 
-export default ThemeSettings
+  const handleModeChange = (e) => {
+    setCurrentMode(e.target.value);
+    localStorage.setItem('themeMode', e.target.value);
+  };
+
+  const handleColorChange = (color) => {
+    setCurrentColor(color);
+    localStorage.setItem('colorMode', color);
+  };
+
+  return (
+    <div className="bg-half-transparent w-screen fixed nav-item top-0 right-0 z-50">
+      <div className="float-right h-screen dark:text-gray-200 bg-white dark:bg-[#33373E] w-400 p-8">
+        <div className="flex justify-between items-center">
+          <p className="font-semibold text-lg">Settings</p>
+          <button
+            type="button"
+            onClick={() => setThemeSettings(false)}
+            className="text-2xl p-3 hover:drop-shadow-xl hover:bg-light-gray"
+          >
+            <MdOutlineCancel />
+          </button>
+        </div>
+        <div className="mt-4 border-t-1 border-color">
+          <p className="font-semibold text-xl mt-4">Theme Options</p>
+          <div className="mt-4">
+            <input
+              id="light"
+              type="radio"
+              name="theme"
+              value="Light"
+              className="cursor-pointer"
+              onChange={handleModeChange}
+              checked={currentMode === 'Light'}
+            />
+            <label htmlFor="light" className="ml-2 text-md cursor-pointer">
+              Light
+            </label>
+          </div>
+          <div className="mt-2">
+            <input
+              id="dark"
+              type="radio"
+              name="theme"
+              value="Dark"
+              className="cursor-pointer"
+              onChange={handleModeChange}
+              checked={currentMode === 'Dark'}
+            />
+            <label htmlFor="dark" className="ml-2 text-md cursor-pointer">
+              Dark
+            </label>
+          </div>
+        </div>
+        <div className="mt-4 border-t-1 border-color">
+          <p className="font-semibold text-xl mt-4">Theme Colors</p>
+          <div className="flex gap-3">
+            {themeColors.map((item) => (
+              <button
+                type="button"
+                key={item.name}
+                className="h-10 w-10 rounded-full cursor-pointer flex items-center justify-center"
+                style={{ backgroundColor: item.color }}
+                onClick={() => handleColorChange(item.color)}
+              >
+                {currentColor === item.color && (
+                  <BsCheck className="text-2xl text-white" />
+                )}
+              </button>
+            ))}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default ThemeSettings;


### PR DESCRIPTION
## Summary
- add a full ThemeSettings panel with color pickers and mode toggles
- load color/mode from local storage and display the panel via settings button
- apply dark mode class and use selected color for the settings button

## Testing
- `npm test -- --watchAll=false`

------
https://chatgpt.com/codex/tasks/task_e_684b44e1e3c083238a8f72bcaf936b27