### PR TITLE
Add grid tests and test script

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,5 +78,5 @@ This section has moved here: [https://facebook.github.io/create-react-app/docs/d
 
 ## Running Tests
 
-Run `npm test -- --watchAll=false` to execute the test suite once. Example tests are in `src/pages/*.test.jsx`.
+Run `npm run test:ci` to execute the test suite once. Tests are located under `src/pages/__tests__` and `src/pages/*.test.jsx`.
 

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "start": "react-scripts start",
     "build": "react-scripts build",
     "test": "react-scripts test",
+    "test:ci": "react-scripts test --watchAll=false",
     "eject": "react-scripts eject"
   },
   "eslintConfig": {

--- a/src/pages/__tests__/AllContents.test.jsx
+++ b/src/pages/__tests__/AllContents.test.jsx
@@ -1,0 +1,22 @@
+import { render, screen } from '@testing-library/react';
+
+jest.mock('../../api/client', () => ({
+  __esModule: true,
+  default: { get: jest.fn() },
+}));
+
+import AllContents from '../Content/AllContents';
+import apiClient from '../../api/client';
+
+describe('AllContents', () => {
+  test('displays rows after fetch', async () => {
+    apiClient.get.mockResolvedValueOnce({ data: [{ Id: 1, Name: 'Test Movie' }] });
+
+    render(<AllContents />);
+
+    expect(apiClient.get).toHaveBeenCalledWith('/contents');
+
+    const row = await screen.findByText('Test Movie');
+    expect(row).toBeInTheDocument();
+  });
+});

--- a/src/pages/__tests__/ShowLicenses.test.jsx
+++ b/src/pages/__tests__/ShowLicenses.test.jsx
@@ -1,0 +1,22 @@
+import { render, screen } from '@testing-library/react';
+
+jest.mock('../../api/client', () => ({
+  __esModule: true,
+  default: { get: jest.fn() },
+}));
+
+import ShowLicenses from '../License/ShowLicenses';
+import apiClient from '../../api/client';
+
+describe('ShowLicenses', () => {
+  test('displays rows after fetch', async () => {
+    apiClient.get.mockResolvedValueOnce({ data: [{ Id: 1, Name: 'Basic License' }] });
+
+    render(<ShowLicenses />);
+
+    expect(apiClient.get).toHaveBeenCalledWith('/licenses');
+
+    const row = await screen.findByText('Basic License');
+    expect(row).toBeInTheDocument();
+  });
+});

--- a/src/setupTests.js
+++ b/src/setupTests.js
@@ -1,1 +1,9 @@
 import '@testing-library/jest-dom';
+import crypto from 'crypto';
+
+// Polyfill for libraries requiring crypto.getRandomValues
+Object.defineProperty(global, 'crypto', {
+  value: {
+    getRandomValues: (arr) => crypto.randomFillSync(arr),
+  },
+});


### PR DESCRIPTION
## Summary
- add grid tests for AllContents and ShowLicenses
- provide crypto polyfill for tests
- add `test:ci` npm script and update docs

## Testing
- `npm run test:ci`


------
https://chatgpt.com/codex/tasks/task_e_684b4de7d19083238a0389b9cbc7db06